### PR TITLE
Handle projects.h not being available

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -6,6 +6,8 @@ if not have_header('proj_api.h')
   raise('Cannot find proj_api.h header')
 end
 
+have_header('projects.h')
+
 unless have_library('proj', 'pj_init') or
        have_library('libproj', 'pj_init')
   raise('Cannot find proj4 library')

--- a/ext/projrb.c
+++ b/ext/projrb.c
@@ -1,15 +1,19 @@
 #include <ruby.h>
+#ifdef HAVE_PROJECTS_H
 #include <projects.h>
+#endif
 #include <proj_api.h>
  
 static VALUE mProjrb;
 
+#ifdef HAVE_PROJECTS_H
 static VALUE cDef;
 static VALUE cDatum;
 static VALUE cEllipsoid;
 static VALUE cPrimeMeridian;
 static VALUE cProjectionType;
 static VALUE cUnit;
+#endif
 
 static VALUE cError;
 static VALUE cProjection;
@@ -97,6 +101,7 @@ static VALUE proj_initialize(VALUE self, VALUE params){
   return self;
 }
 
+#ifdef HAVE_PROJECTS_H
 /**Has this projection an inverse?
 
    call-seq: hasInverse? -> true or false
@@ -107,6 +112,7 @@ static VALUE proj_has_inverse(VALUE self){
   Data_Get_Struct(self,_wrap_pj,wpj);
   return wpj->pj->inv ? Qtrue : Qfalse;
 }
+#endif
 
 /**Is this projection a latlong projection?
 
@@ -250,7 +256,7 @@ static VALUE proj_transform(VALUE self, VALUE dst, VALUE point){
   return self; /* Makes gcc happy */
 }
 
-#if PJ_VERSION >= 449
+#if PJ_VERSION >= 449 && defined(HAVE_PROJECTS_H)
 /**Return list of all datums we know about.
 
    call-seq: list -> Array of Proj4::Datum
@@ -508,7 +514,9 @@ void Init_proj4_ruby(void) {
   cProjection = rb_define_class_under(mProjrb,"Projection",rb_cObject);
   rb_define_alloc_func(cProjection,proj_alloc);
   rb_define_method(cProjection,"initialize",proj_initialize,1);
+#ifdef HAVE_PROJECTS_H
   rb_define_method(cProjection,"hasInverse?",proj_has_inverse,0);
+#endif
   rb_define_method(cProjection,"isLatLong?",proj_is_latlong,0);
   rb_define_method(cProjection,"isGeocent?",proj_is_geocent,0);
   rb_define_alias(cProjection,"isGeocentric?","isGeocent?");
@@ -517,7 +525,7 @@ void Init_proj4_ruby(void) {
   rb_define_method(cProjection,"inverse!",proj_inverse,1);
   rb_define_method(cProjection,"transform!",proj_transform,2);
 
-  #if PJ_VERSION >= 449
+  #if PJ_VERSION >= 449 && defined(HAVE_PROJECTS_H)
     cDef = rb_define_class_under(mProjrb,"Def",rb_cObject);
 
     /* The Datum class holds information about datums ('WGS84', 'potsdam', ...) known to Proj.4. */


### PR DESCRIPTION
Starting with proj4 4.8.0 the projects.h header is no longer intended to be installed - the NEWS file says:
- projects.h no longer installed as a public include file.  Please try to only use proj_api.h. 

Ubuntu at least has now stopped including it in their package, though Fedora still does.

This PR allows proj4rb to detect when the header is missing - unfortunately certain methods which rely on access to the library internals then have to be disabled.

I'm not quite sure if this is the right place to send this change though, as rubygems.org has a 0.4.3 release which doesn't seem to be in your repo, but I haven't managed to work out where it did come from.
