### PR TITLE
moved proj_context_set_autoclose_database to api 6.2

### DIFF
--- a/lib/api/api_6_0.rb
+++ b/lib/api/api_6_0.rb
@@ -21,8 +21,7 @@ module Proj
     attach_function :proj_as_wkt, [:PJ_CONTEXT, :PJ, :PJ_WKT_TYPE, :pointer], :string
     attach_function :proj_as_proj_string, [:PJ_CONTEXT, :PJ, :PJ_PROJ_STRING_TYPE, :pointer], :string
 
-    # Projection database functions
-    attach_function :proj_context_set_autoclose_database, [:PJ_CONTEXT, :int], :void
+    # Projection database functions    
     attach_function :proj_context_set_database_path, [:PJ_CONTEXT, :string, :pointer, :pointer], :int
     attach_function :proj_context_get_database_path, [:PJ_CONTEXT], :string
     attach_function :proj_context_get_database_metadata, [:PJ_CONTEXT, :string], :string

--- a/lib/api/api_6_2.rb
+++ b/lib/api/api_6_2.rb
@@ -2,5 +2,6 @@ module Proj
   module Api
     attach_function :proj_as_projjson, [:PJ_CONTEXT, :PJ, :pointer], :string
     attach_function :proj_create_crs_to_crs_from_pj, [:PJ_CONTEXT, :PJ, :PJ, :PJ_AREA, :string], :PJ
+    attach_function :proj_context_set_autoclose_database, [:PJ_CONTEXT, :int], :void
   end
 end


### PR DESCRIPTION
moved proj_context_set_autoclose_database to api v 6.2 as it was introduced in 6.2 (see docs https://proj.org/development/reference/functions.html)
