### PR TITLE
Add macOS to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: CPU architecture
+        run: uname -p
       - name: Install Proj (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: proj4rb
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   proj_8:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,26 @@ name: proj4rb
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  proj_8:
+  test:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-13, macos-14]
         ruby: [3.2, 3.3]
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Proj
-        run: sudo apt-get install libproj22
+      - name: Install Proj (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install libproj22
+      - name: Install Proj (Mac)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew update
+          brew install proj
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
As requested in https://github.com/cfis/proj4rb/issues/23#issuecomment-2048356002, this PR adds two [macOS configurations](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) to the test matrix.

1. `macos-13` instances run on Intel processors
2. `macos-14` instances run on Apple Silicon (ARM)

As discussed in #23, it seems evident that this gem (or the FFI layer) behaves differently under different hardware/software configurations. This CI change broadens the coverage to include common developer machine configurations.